### PR TITLE
fix: replace hardcoded English strings with i18n translations

### DIFF
--- a/platform/src/app/[locale]/courses/page.tsx
+++ b/platform/src/app/[locale]/courses/page.tsx
@@ -144,10 +144,10 @@ export default function CoursesPage() {
         if (data.success) {
           setCourses(data.data)
         } else {
-          setError(data.message || 'Failed to load courses')
+          setError(data.message || t('fetchError'))
         }
       } catch {
-        setError('Failed to load courses')
+        setError(t('fetchError'))
       } finally {
         setLoading(false)
       }

--- a/platform/src/app/[locale]/dashboard/page.tsx
+++ b/platform/src/app/[locale]/dashboard/page.tsx
@@ -48,7 +48,7 @@ function formatDate(dateString: string, locale: string): string {
   })
 }
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status, label }: { status: string; label: string }) {
   const statusStyles: Record<string, string> = {
     completed: 'bg-green-500/20 text-green-400',
     pending: 'bg-yellow-500/20 text-yellow-400',
@@ -60,7 +60,7 @@ function StatusBadge({ status }: { status: string }) {
 
   return (
     <span className={`px-2 py-1 rounded-full text-xs font-medium ${style}`}>
-      {status}
+      {label}
     </span>
   )
 }
@@ -79,12 +79,12 @@ export default function DashboardPage() {
       try {
         const response = await fetch('/api/dashboard')
         if (!response.ok) {
-          throw new Error('Failed to fetch dashboard stats')
+          throw new Error(t('fetchError'))
         }
         const data = await response.json()
         setStats(data.data)
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'An error occurred')
+        setError(err instanceof Error ? err.message : t('genericError'))
       } finally {
         setLoading(false)
       }
@@ -130,7 +130,7 @@ export default function DashboardPage() {
           <StatCard title={t('totalUsers')} value={stats.totalUsers} />
           <StatCard title={t('totalCourses')} value={stats.totalCourses} />
           <StatCard title={t('totalOrders')} value={stats.totalOrders} />
-          <StatCard title={t('totalRevenue')} value={stats.totalRevenue} suffix="CNY" />
+          <StatCard title={t('totalRevenue')} value={stats.totalRevenue} suffix={t('currency')} />
         </div>
 
         {/* Recent Users */}
@@ -186,9 +186,9 @@ export default function DashboardPage() {
                   <tr key={order.id} className="hover:bg-white/5 transition-colors">
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-white">{order.courseName}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-300">{order.userName}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-300">{order.amount} CNY</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-300">{order.amount} {t('currency')}</td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <StatusBadge status={order.status} />
+                      <StatusBadge status={order.status} label={t(`statuses.${order.status}`)} />
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">{formatDate(order.createdAt, locale)}</td>
                   </tr>

--- a/platform/src/i18n/dictionaries/en.json
+++ b/platform/src/i18n/dictionaries/en.json
@@ -217,7 +217,8 @@
     "purchaseSuccess": "🎉 Purchase successful! \"{courseName}\" has been added to your courses.",
     "purchaseFailed": "Purchase failed, please try again.",
     "networkError": "Network error, please try again.",
-    "close": "Close"
+    "close": "Close",
+    "fetchError": "Failed to load courses"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -231,6 +232,15 @@
     "recentOrders": "Recent Orders",
     "noUsers": "No users yet",
     "noOrders": "No orders yet",
+    "fetchError": "Failed to fetch dashboard data",
+    "genericError": "An error occurred",
+    "currency": "CNY",
+    "statuses": {
+      "completed": "Completed",
+      "pending": "Pending",
+      "failed": "Failed",
+      "refunded": "Refunded"
+    },
     "tableHeaders": {
       "name": "Name",
       "email": "Email",

--- a/platform/src/i18n/dictionaries/zh.json
+++ b/platform/src/i18n/dictionaries/zh.json
@@ -217,7 +217,8 @@
     "purchaseSuccess": "🎉 购买成功！「{courseName}」已加入你的课程。",
     "purchaseFailed": "购买失败，请重试。",
     "networkError": "网络错误，请重试。",
-    "close": "关闭"
+    "close": "关闭",
+    "fetchError": "加载课程失败"
   },
   "dashboard": {
     "title": "数据看板",
@@ -231,6 +232,15 @@
     "recentOrders": "最近订单",
     "noUsers": "暂无用户",
     "noOrders": "暂无订单",
+    "fetchError": "获取数据看板数据失败",
+    "genericError": "发生错误",
+    "currency": "元",
+    "statuses": {
+      "completed": "已完成",
+      "pending": "待处理",
+      "failed": "失败",
+      "refunded": "已退款"
+    },
     "tableHeaders": {
       "name": "姓名",
       "email": "邮箱",


### PR DESCRIPTION
## Summary

Replaced all hardcoded English strings in dashboard and courses pages with proper i18n translations.

## Changes

- en.json: Added fetchError, genericError, currency, statuses keys to dashboard; fetchError to courses
- zh.json: Added corresponding Chinese translations
- dashboard/page.tsx: Replaced hardcoded English with useTranslations() calls
- courses/page.tsx: Replaced hardcoded error message with t('fetchError')

Fixes AIwork4me/ceo-of-one#3