### PR TITLE
feat: add pulse/glow animation to hero CTA button #9

### DIFF
--- a/platform/src/app/[locale]/page.tsx
+++ b/platform/src/app/[locale]/page.tsx
@@ -19,7 +19,7 @@ function Hero() {
         </p>
         <a
           href="#pricing"
-          className="inline-block bg-accent hover:bg-accent-hover text-white px-8 py-4 rounded-xl text-lg font-semibold transition-all transform hover:scale-105 shadow-lg shadow-accent/30"
+          className="inline-block cta-pulse-glow bg-accent hover:bg-accent-hover text-white px-8 py-4 rounded-xl text-lg font-semibold transition-all transform hover:scale-105 shadow-lg shadow-accent/30"
         >
           {t('cta')}
         </a>

--- a/platform/src/app/globals.css
+++ b/platform/src/app/globals.css
@@ -10,3 +10,20 @@ body {
   background-color: #0a0a0a;
   color: #ffffff;
 }
+
+@keyframes cta-pulse-glow {
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(234, 179, 8, 0.3), 0 10px 15px -3px rgba(234, 179, 8, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 35px rgba(234, 179, 8, 0.5), 0 0 60px rgba(234, 179, 8, 0.2), 0 10px 15px -3px rgba(234, 179, 8, 0.3);
+  }
+}
+
+.cta-pulse-glow {
+  animation: cta-pulse-glow 2.5s ease-in-out infinite;
+}
+
+.cta-pulse-glow:hover {
+  animation: none;
+}


### PR DESCRIPTION
## Summary

Add a subtle pulse/glow animation to the hero section CTA button to draw user attention.

### Changes
- Added cta-pulse-glow CSS animation in globals.css using a smooth 2.5s ease-in-out infinite keyframe that modulates box-shadow glow intensity
- Applied the animation class to the hero CTA button in page.tsx
- Animation pauses on hover (returns to static state) for a clean interaction feel

Closes #9