### PR TITLE
fix: #13 Add Back to Top button

### DIFF
--- a/platform/src/app/[locale]/layout.tsx
+++ b/platform/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { getMessages } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import '../globals.css'
 import { routing } from '@/i18n/routing'
+import BackToTop from '@/components/BackToTop'
 
 const notoSansSC = Noto_Sans_SC({
   subsets: ['latin'],
@@ -103,6 +104,7 @@ export default async function LocaleLayout({
       <body className="font-sans antialiased">
         <NextIntlClientProvider messages={messages}>
           {children}
+          <BackToTop />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/platform/src/components/BackToTop.tsx
+++ b/platform/src/components/BackToTop.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useTranslations } from 'next-intl'
+
+export default function BackToTop() {
+  const t = useTranslations('backToTop')
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 300)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  if (!visible) return null
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label={t('tooltip')}
+      title={t('tooltip')}
+      className="fixed bottom-6 right-6 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-gray-800 text-white shadow-lg transition-opacity hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={2}
+        stroke="currentColor"
+        className="h-5 w-5"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+      </svg>
+    </button>
+  )
+}

--- a/platform/src/i18n/dictionaries/en.json
+++ b/platform/src/i18n/dictionaries/en.json
@@ -367,5 +367,8 @@
   "languageSwitcher": {
     "en": "English",
     "zh": "中文"
+  },
+  "backToTop": {
+    "tooltip": "Back to top"
   }
 }

--- a/platform/src/i18n/dictionaries/zh.json
+++ b/platform/src/i18n/dictionaries/zh.json
@@ -367,5 +367,8 @@
   "languageSwitcher": {
     "en": "English",
     "zh": "中文"
+  },
+  "backToTop": {
+    "tooltip": "回到顶部"
   }
 }


### PR DESCRIPTION
## Summary

Adds a minimal, unobtrusive "Back to Top" button that appears when the user scrolls down on any page. Uses smooth scroll behavior and supports i18n for the tooltip/accessibility text.

## Changes

- Added `BackToTop` component in `platform/src/components/BackToTop.tsx`
- Wired it into the `[locale]/layout.tsx` so it appears on all pages
- Updated `en.json` with `backToTop.tooltip`: "Back to top"
- Updated `zh.json` with `backToTop.tooltip`: "回到顶部"

## Testing

- 111 tests passed
- `npm run build` successful

Closes #13