### PR TITLE
fix: improve 404 page - #15

### DIFF
--- a/platform/src/app/[locale]/not-found.tsx
+++ b/platform/src/app/[locale]/not-found.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import Link from 'next/link'
+import { useTranslations } from 'next-intl'
+
+export default function NotFound() {
+  const t = useTranslations('notFound')
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-dark-bg to-[#1a1a2e]">
+      <div className="text-center px-4">
+        <div className="text-8xl mb-6">🔍</div>
+        <h1 className="text-6xl font-bold text-white mb-4">404</h1>
+        <h2 className="text-2xl text-gray-300 mb-4">{t('title')}</h2>
+        <p className="text-gray-400 mb-8 max-w-md mx-auto">{t('description')}</p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors"
+        >
+          {t('backHome')}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/platform/src/i18n/dictionaries/en.json
+++ b/platform/src/i18n/dictionaries/en.json
@@ -370,5 +370,10 @@
   },
   "backToTop": {
     "tooltip": "Back to top"
+  },
+  "notFound": {
+    "title": "Page Not Found",
+    "description": "The page you're looking for doesn't exist or has been moved. Let's get you back on track.",
+    "backHome": "Back to Home"
   }
 }

--- a/platform/src/i18n/dictionaries/zh.json
+++ b/platform/src/i18n/dictionaries/zh.json
@@ -370,5 +370,10 @@
   },
   "backToTop": {
     "tooltip": "回到顶部"
+  },
+  "notFound": {
+    "title": "页面未找到",
+    "description": "你访问的页面不存在或已被移动。让我们帮你回到正轨。",
+    "backHome": "返回首页"
   }
 }


### PR DESCRIPTION
Fixes #15: Improve the 404 page with i18n-friendly design.

- Created \
ot-found.tsx\ with friendly 404 page using next-intl
- Added English and Chinese translations for 404 page
- Page shows emoji, title, description, and back-to-home link
- Matches existing site styling (gradient background, accent colors)
- All 111 tests pass, build succeeds